### PR TITLE
Undo LETS GOOOOO

### DIFF
--- a/Puzzling Forest/Assets/Resources/Misc/GameManager.prefab
+++ b/Puzzling Forest/Assets/Resources/Misc/GameManager.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 2540174764805835783}
   - component: {fileID: 2540174764805835776}
   - component: {fileID: 2295815160219363479}
+  - component: {fileID: 3940069797222323089}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -59,6 +60,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   timeUI: {fileID: 0}
   isLevelComplete: 0
+--- !u!114 &3940069797222323089
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2540174764805835777}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4a21c4a8322f51b41bd41d726c49a62f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &6325970486571875838
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Puzzling Forest/Assets/Scripts/Turn Manager/UndoManager.cs
+++ b/Puzzling Forest/Assets/Scripts/Turn Manager/UndoManager.cs
@@ -1,0 +1,107 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class UndoManager : MonoBehaviour
+{
+    private class SingleTurnState
+    {
+        public List<StateInfo> turnState;
+
+        public void AddState(GameObject incomingGO)
+        {
+            turnState.Add(new StateInfo(incomingGO));
+        }
+
+        public void Reset()
+        {
+            turnState.Clear();
+        }
+
+        public SingleTurnState Copy()
+        {
+            SingleTurnState retState = new SingleTurnState(turnState);
+            return retState;
+        }
+
+
+
+        //Construction
+        public SingleTurnState(List<StateInfo> TurnState)
+        {
+            turnState = new List<StateInfo>(TurnState);
+        }
+        public SingleTurnState()
+        {
+            turnState = new List<StateInfo>();
+        }
+        //Print
+        public override string ToString()
+        {
+            string retString = "Things that moved this turn and their original position:";
+            for (int i = 0; i < turnState.Count; i++)
+            {
+                retString += turnState[i].ToString();
+            }
+            return retString;
+        }
+    }
+
+    public struct StateInfo
+    {
+        public GameObject GO;
+        public Vector3 position;
+        public Quaternion rotation;
+
+        public StateInfo(GameObject incomingGO)
+        {
+            GO = incomingGO;
+            position = GO.transform.position;
+            if (GO.CompareTag("Player"))
+                rotation = GO.transform.Find("Fox").rotation;
+            else
+                rotation = GO.transform.rotation;
+        }
+
+        //Print
+        public override string ToString()
+        {
+            string retString = "\n - GameObject: " + GO.name;
+            retString += "\n    - " + position + "\n    - " + rotation;
+            return retString;
+        }
+    }
+
+    private Stack<SingleTurnState> undoStack = new Stack<SingleTurnState>();
+    private SingleTurnState curTurnState = new SingleTurnState();
+
+    public void LogState(GameObject incomingGO)
+    {
+        //Debug.LogFormat("adding {0} to curTurnState", incomingGO.name);
+        curTurnState.AddState(incomingGO);
+    }
+
+    public void WriteTurnState()
+    {
+        undoStack.Push(curTurnState.Copy());
+        curTurnState.Reset();
+    }
+
+    public void UndoTurn()
+    {
+        if (undoStack.Count > 0)
+        {
+            SingleTurnState prevState = undoStack.Pop();
+
+            foreach (StateInfo state in prevState.turnState)
+            {
+                state.GO.GetComponent<TurnBasedCharacter>().UndoMyTurn(state.position, state.rotation);
+            }
+        }
+        else
+        {
+            //do nothing, someone hit undo before a move was made
+            Debug.Log("Can't undo, no move is on stack");
+        }
+    }
+}

--- a/Puzzling Forest/Assets/Scripts/Turn Manager/UndoManager.cs.meta
+++ b/Puzzling Forest/Assets/Scripts/Turn Manager/UndoManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4a21c4a8322f51b41bd41d726c49a62f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Puzzling Forest/Assets/Scripts/Walls/DestroyBounds.cs
+++ b/Puzzling Forest/Assets/Scripts/Walls/DestroyBounds.cs
@@ -10,6 +10,11 @@ public class DestroyBounds : MonoBehaviour
 {
     void OnTriggerEnter(Collider other)
     {
-        Destroy(other.gameObject);
+        Hide(other.gameObject);
+    }
+
+    private void Hide(GameObject GO)
+    {
+        GO.SetActive(false);
     }
 }

--- a/Puzzling Forest/Assets/Scripts/Walls/PushableTurnBasedObject.cs
+++ b/Puzzling Forest/Assets/Scripts/Walls/PushableTurnBasedObject.cs
@@ -99,7 +99,11 @@ public class PushableTurnBasedObject : TurnBasedCharacter
         
         if (OkayToMoveToNextTile(targetPosition))
         {
-            Debug.Log(this.gameObject.name + " is being pushed to " + targetPosition);
+            //Debug.Log(this.gameObject.name + " is being pushed to " + targetPosition);
+
+            //undo stuff
+            undoManager.LogState(this.gameObject);
+
             targetMoveToPosition = targetPosition;
             return true;
         }


### PR DESCRIPTION
Added an undo manager and hooked it up to the turn-based-character script(s). Keeps a stack of turn states (everything that moved in a turn) and can pop off turns to undo them.
Also changed the destroyBounds script to hide the game objects instead of destroying them because otherwise you can't move them back.
Added the new Undo Manager script to the GameManager prefab.