### PR TITLE
BugFix for Auto-Swap

### DIFF
--- a/Puzzling Forest/Assets/Cube_World/Prefabs/Buildings/House_01.prefab
+++ b/Puzzling Forest/Assets/Cube_World/Prefabs/Buildings/House_01.prefab
@@ -97,7 +97,7 @@ BoxCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 1.1153519, y: 1.84232, z: 1.1225691}
+  m_Size: {x: 0.5, y: 1.84232, z: 0.5}
   m_Center: {x: 0.028982013, y: 1.370606, z: 0.011517495}
 --- !u!114 &103504843046911775
 MonoBehaviour:

--- a/Puzzling Forest/Assets/Scripts/Fox_etc/FoxCharacter.cs
+++ b/Puzzling Forest/Assets/Scripts/Fox_etc/FoxCharacter.cs
@@ -170,7 +170,7 @@ public class FoxCharacter : TurnBasedCharacter
 
     public override void UndoMyTurn(Vector3 oldPosition, Quaternion oldRotation)
     {
-        this.gameObject.transform.Find("Fox").rotation = oldRotation;
+        this.gameObject.transform.Find("Fox").transform.rotation = oldRotation;
 
         this.gameObject.transform.position = oldPosition;
         targetMoveToPosition = oldPosition;
@@ -249,7 +249,25 @@ public class FoxCharacter : TurnBasedCharacter
     public void StopTakingTurns()
     {
         isTakingTurns = false;
-        turnManager.SwapFoxes();
+        StartCoroutine(QueueStopTakingTurns());
+    }
+
+    //If we don't wait for the first fox to finish it's animation, it will call CompleteAnimation()
+    // as soon as it is done animating. IF that is in the middle of the Fox-Swap animation, this
+    // will allow for the fox to take over too soon.
+    private IEnumerator QueueStopTakingTurns()
+    {
+        while (true)
+        {
+            if (isAnimating)
+                yield return null;
+            else
+            {
+                turnManager.PressKey();
+                turnManager.SwapFoxes();
+                yield break;
+            }
+        }
     }
 
     public void StartTakingTurns()

--- a/Puzzling Forest/Assets/Scripts/Fox_etc/IndicatorAnimationController.cs
+++ b/Puzzling Forest/Assets/Scripts/Fox_etc/IndicatorAnimationController.cs
@@ -316,7 +316,6 @@ public class IndicatorAnimationController : MonoBehaviour
     {
         if (info.msg == "") //nothing to say.
         {
-            Debug.Log("here");
             return -1f;
         }
 

--- a/Puzzling Forest/Assets/Scripts/Managers/TurnManager.cs
+++ b/Puzzling Forest/Assets/Scripts/Managers/TurnManager.cs
@@ -69,7 +69,7 @@ public class TurnManager : MonoBehaviour
                 {
                     //camera mode is toggled (this is done in a camera script)
                 }
-                if (curPlayer && !curPlayer.GetIsMoving() && !isAnimating && !cameraLock && !keyJustPressed)
+                if (curPlayer && !curPlayer.GetIsMoving() && curPlayer.CheckIfTakingTurns() && !isAnimating && !cameraLock && !keyJustPressed)
                     if (Input.GetKeyDown(KeyCode.E))
                     {
                         PressKey();
@@ -327,12 +327,12 @@ public class TurnManager : MonoBehaviour
     // While the flag is set, user input is not accepted.
     public void beginAnimation()
     {
-        //Debug.Log("begin anim" + Time.time);
+        //Debug.Log("begin anim at: " + Time.time);
         isAnimating = true;
     }
     public void completeAnimation()
     {
-        //Debug.Log("complete anim" + Time.time);
+        //Debug.Log("complete anim at: " + Time.time);
         isAnimating = false;
     }
 

--- a/Puzzling Forest/Assets/Scripts/Managers/UndoManager.cs
+++ b/Puzzling Forest/Assets/Scripts/Managers/UndoManager.cs
@@ -58,7 +58,7 @@ public class UndoManager : MonoBehaviour
             GO = incomingGO;
             position = GO.transform.position;
             if (GO.CompareTag("Player"))
-                rotation = GO.transform.Find("Fox").rotation;
+                rotation = GO.transform.Find("Fox").transform.rotation;
             else
                 rotation = GO.transform.rotation;
         }


### PR DESCRIPTION
- When Fox1 entered the house, if the player held down a rotate key, Fox2 could be made to go diagonal.
- This is the bug fix for that. The issue had to do with calling SwapFox() before the walking animation was completed. When Fox1 was done walking, it would call CompleteAnimation() in the middle of the SwapFox animation thus giving Fox2 control too soon.
- Also an issue: The house box collider was overflowing its tile. This sometimes caused the level complete condition to trigger too soon.